### PR TITLE
Fix Docker live reload for local source changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
       target: runtime
     ports:
       - '8011:8011'
+    volumes:
+      - ./_src:/app
+      - /app/node_modules
   test:
     build:
       context: .


### PR DESCRIPTION
## Summary

- bind the host `_src` directory to `/app`, where the runtime image executes Eleventy
- preserve image-installed dependencies with an anonymous `/app/node_modules` volume
- allow Eleventy to observe local file changes without rebuilding or restarting the container

Closes #61.

## Verification

- `docker compose config --quiet`
- confirmed normalized mounts: host `_src` → `/app` and anonymous volume → `/app/node_modules`
- started the existing site image through the updated Compose configuration; `/` returned HTTP 200
- touched host `_src/index.pug`; the running container logged `File changed: ./index.pug` and rebuilt 17 pages without restarting; `/` continued returning HTTP 200
- lint passed
- TypeScript typecheck passed
- unit tests: 39 passed
- accessibility tests: 3 passed
- E2E tests with `CI=1`: 5 passed

## Existing build caveat

A completely fresh Docker build currently stops at the existing `RUN npm audit fix` step in `Dockerfile` because npm exits nonzero for the current dependency audit. That failure predates and is unrelated to this Compose-only change; the live-reload behavior was exercised using the existing runtime image.